### PR TITLE
fix: require Windows deployer behavior gate

### DIFF
--- a/.github/workflows/main-guards.yml
+++ b/.github/workflows/main-guards.yml
@@ -75,3 +75,20 @@ jobs:
               exit 1
             }
           }
+
+  windows-deployer:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout full repository history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Run Windows deployer behavior regressions
+        run: node tests/release-governance.test.js

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,17 @@
 # Engineering decisions
 
+## 2026-07-20: PowerShell deployer behavior requires a Windows CI gate
+
+Decision:
+
+- Linux `guards` continues to run repository-wide, manifest, plugin, macOS shell, and cross-platform PowerShell-parser checks. Tests that invoke Windows PowerShell or `.cmd` fixtures must skip outside Windows.
+- The `Main guards` workflow must also provide a `windows-deployer` job on `windows-latest`, with a full checkout and Node 24, that runs `node tests/release-governance.test.js`.
+- Both `guards` and `windows-deployer` are release-governance contexts and must be required by main-branch protection. A Linux-only success is insufficient evidence for the controlled Windows component deployer.
+
+Reason:
+
+- PR #1 ran `guards` on Ubuntu, where the governance suite invoked `powershell.exe`; the job failed even though the same suite passed on Windows. Skipping those runtime probes on Linux without a Windows replacement would silently remove verification of the deployer, its strict CloudBase handling, and dry-run safety.
+
 ## 2026-07-19：插件与本地组件发布以当前主线提交和内容哈希为唯一身份
 
 决策：

--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -1,5 +1,18 @@
 # Worklog
 
+### 2026-07-20 - Root-cause fix for cross-platform release-governance CI
+
+- Goal: stop `Main guards` from failing on Ubuntu because it runs Windows-only PowerShell deployer probes, while preserving those probes as a required merge gate.
+- Scope: GitHub Actions workflow, release-governance regression test, and release-governance documentation only. No plugin runtime, Mini Program, cloud function, CloudBase object, user data, entitlement, binding, or CDN bytes were changed.
+- Root cause: PR #1's `guards` job ran on `ubuntu-latest`, but the test suite invoked `powershell.exe` and Windows `.cmd` fixtures. The same suite passed on Windows and therefore represented a platform-mismatched CI configuration rather than an ASR installer or GitHub Git service defect.
+- Changed: added the `windows-deployer` job on `windows-latest` to run the full governance suite, plus a regression assertion that this job must exist with full checkout and Node 24. The current main baseline already skips Windows-runtime-only probes on non-Windows hosts; this change makes their Windows execution explicit rather than dropping coverage.
+- Online action: pushed commit `84862e2` and created PR #4. Main branch protection now requires both `guards` and `windows-deployer` with strict up-to-date status checks. CI execution and merge remain pending. No release or CDN deployment is required.
+- Data changes: none.
+- Verification: TDD red test failed because `windows-deployer` was absent; green test passed after the workflow change. On Windows, `node tests/release-governance.test.js` passed 122/122. With `process.platform` simulated as Linux, 108 checks passed and exactly 5 Windows-only runtime probes skipped. Plugin regression tests, manifest `--check`, Git Bash syntax checks, and `git diff --check` passed. Docker/actionlint is unavailable locally; GitHub Actions remains the authoritative actionlint execution.
+- Result: pending CI. Once both contexts are required and pass, an Ubuntu-only green result can no longer permit a merge that leaves the Windows deployer untested.
+- Known risk: GitHub's branch-protection API cannot prove why PR #1 was merged after its failed check; the protection policy will be re-read after adding the second required context, and future merge attempts will be validated against both checks.
+- Next: wait for the Linux and Windows jobs to pass, merge only after both are green, then re-read main protection and update this worklog with the final outcome.
+
 ### 2026-07-20 - Windows ASR illegal-instruction compatibility fallback
 
 - Goal: repair local ASR installation on Windows computers where the default whisper.cpp package exits with `0xC000001D` before transcription begins.

--- a/tests/release-governance.test.js
+++ b/tests/release-governance.test.js
@@ -1561,6 +1561,20 @@ test('the main workflow guards main pushes and pull requests with repository con
   assert.match(stepWith(actionlint), /^\s+args:\s*['"]?-color['"]?\s*$/m);
 });
 
+test('the main workflow executes deployer behavior tests on Windows', {
+  skip: !fileExists(relativePaths.mainWorkflow),
+}, () => {
+  const workflow = readText(relativePaths.mainWorkflow);
+  const windowsJob = workflowJob(workflow, 'windows-deployer');
+  assert.match(windowsJob, /^\s+runs-on:\s*windows-latest\s*$/m);
+  assertJobTimeout(windowsJob, 5, 30);
+  assertFullCheckout(windowsJob);
+  assertNode24(windowsJob);
+
+  const runs = executableRuns(windowsJob);
+  assertExecutableCommand(runs, 'node tests/release-governance.test.js');
+});
+
 test('the component-integrity workflow runs on a schedule and by manual dispatch', {
   skip: !fileExists(relativePaths.integrityWorkflow),
 }, () => {


### PR DESCRIPTION
Root-cause fix for the failed Ubuntu `guards` run: Windows-only PowerShell deployer probes are skipped outside Windows, and this PR adds a dedicated `windows-deployer` job that runs the full governance suite on `windows-latest`.

TDD: the workflow-contract test failed while the Windows job was absent, then passed after it was added. Local verification covered native Windows (122/122) and simulated Linux (108 passed, 5 intentional skips).