### PR TITLE
fix: repair Windows OCR DLL imports automatically

### DIFF
--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -1,5 +1,17 @@
 # Worklog
 
+### 2026-07-21 - Windows OCR ONNX Runtime DLL 自动兼容修复
+
+- 目标：修复 Windows 上 OCR 依赖安装成功但 `onnxruntime_pybind11_state` 因 DLL 加载失败而无法导入的问题，避免要求用户手动结束 Python 进程、重命名目录或自行安装依赖。
+- 影响范围：仅 Windows OCR 安装器、组件清单、发布包回归测试和工作日志；不修改用户本地插件、已有 OCR 正式目录、ASR、小程序、云函数、绑定码或业务数据。
+- 修改文件：`obsidian-plugin/wechat-inbox-sync/local-ocr/install-local-ocr.ps1`、`obsidian-plugin/wechat-inbox-sync/local-components-manifest.json`、`tests/plugin-marketplace-package.test.js`、`docs/WORKLOG.md`。
+- 线上动作：待本修复合并到 `main` 后，通过受控本地组件部署器更新 Windows OCR 安装器的不可变对象、兼容别名和公网组件清单；本次不需要升级 Obsidian 插件版本。
+- 数据变更：无。
+- 验证：先新增固定原生依赖和 DLL 兼容回退断言，确认旧安装器失败；实现后 `node tests/plugin-main-ai.test.js`、`node tests/plugin-marketplace-package.test.js`、`node tests/release-governance.test.js`（122/122）、组件清单一致性、插件 JavaScript 语法、PowerShell AST 解析和 `git diff --check` 通过。在隔离目录使用固定 CPython `3.12.13` 从腾讯镜像真实安装 `rapidocr-onnxruntime 1.4.4 + onnxruntime 1.20.1 + numpy 1.26.4 + opencv-python 4.10.0.84`，四个模块均成功导入且 `RapidOCR()` 初始化成功。
+- 结果：Windows 首选 OCR 原生依赖由隐式浮动改为完整固定；若导入命中 DLL/VC++ 特征，安装器先自动强制替换为经验证的 Windows 10 兼容栈，仍失败才调用微软官方 VC++ 运行库修复。环境继续在 `venv-staging` 构建并切换为唯一正式 `venv`，不会长期留下多个组件版本目录。
+- 已知风险：尚未在截图对应的故障电脑上回归；若兼容栈和微软运行库修复后仍失败，最可能是安全软件拦截或系统组件损坏，新的 `install.log` 会保留逐模块错误用于继续定位。
+- 下一步：完成合并和受控 CDN 部署后，让受影响用户在插件设置中再次点击一次“安装/修复本地转写组件”。
+
 ### 2026-07-20 - 小红书图集只保留每页最高质量图片（1.3.52）
 
 - 目标：修复小红书 `imageList` 同一页同时包含缩略图与高质量图时，插件把两者都下载、写入笔记并重复 OCR 的问题。

--- a/obsidian-plugin/wechat-inbox-sync/local-components-manifest.json
+++ b/obsidian-plugin/wechat-inbox-sync/local-components-manifest.json
@@ -32,8 +32,8 @@
     {
       "id": "ocr-windows-installer",
       "sourcePath": "local-ocr/install-local-ocr.ps1",
-      "sha256": "6860e544be579ecf66f39b7d06706150a62eb7d0c19f2a31016084e3984f8f8d",
-      "immutablePath": "local-components/by-sha256/6860e544be579ecf66f39b7d06706150a62eb7d0c19f2a31016084e3984f8f8d/install-local-ocr.ps1",
+      "sha256": "58987dde9d22e97428eb3fe2a6705b702856e6450e308a7659b7f311d27b894e",
+      "immutablePath": "local-components/by-sha256/58987dde9d22e97428eb3fe2a6705b702856e6450e308a7659b7f311d27b894e/install-local-ocr.ps1",
       "compatibilityAlias": "local-ocr/common/install-local-ocr.ps1"
     },
     {

--- a/obsidian-plugin/wechat-inbox-sync/local-ocr/install-local-ocr.ps1
+++ b/obsidian-plugin/wechat-inbox-sync/local-ocr/install-local-ocr.ps1
@@ -28,7 +28,20 @@ $PythonBuildStandaloneVersion = "3.12.13+20260623"
 $PythonRuntimeFileName = "cpython-$PythonBuildStandaloneVersion-x86_64-pc-windows-msvc-install_only.tar.gz"
 $PythonRuntimeSha256 = "C6AF85BB83D5158C9FF71F50DFAD467853D1CD236F932B144E87E26E2EA2A83E"
 $PortablePython = Join-Path $PythonRuntimeDir "python\python.exe"
-$OcrPackageRequirements = @("rapidocr-onnxruntime==1.4.4", "pillow==12.3.0")
+$OcrPackageRequirements = @(
+  "rapidocr-onnxruntime==1.4.4",
+  "pillow==12.3.0",
+  "onnxruntime==1.27.0",
+  "numpy==2.5.1",
+  "opencv-python==5.0.0.93"
+)
+$OcrCompatibilityPackageRequirements = @(
+  "rapidocr-onnxruntime==1.4.4",
+  "pillow==12.3.0",
+  "onnxruntime==1.20.1",
+  "numpy==1.26.4",
+  "opencv-python==4.10.0.84"
+)
 $MicrosoftVisualCppRuntimeUrl = "https://aka.ms/vs/17/release/vc_redist.x64.exe"
 $MicrosoftVisualCppRuntimeInstaller = Join-Path $BinDir "vc_redist.x64.exe"
 $script:LastOcrImportFailureModule = ""
@@ -37,6 +50,7 @@ $script:LastOcrImportFailureText = ""
 $script:VisualCppRuntimeRepairAttempted = $false
 $script:VisualCppRuntimeRepairFailureMessage = ""
 $script:VisualCppRuntimeRestartRequired = $false
+$script:OcrCompatibilityRepairAttempted = $false
 New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
 New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
 New-Item -ItemType Directory -Force -Path $CacheDir | Out-Null
@@ -329,6 +343,20 @@ function Test-OcrPythonReady {
     return $true
   }
 
+  if (!(Test-MissingVisualCppRuntime)) {
+    return $false
+  }
+
+  if (!$script:OcrCompatibilityRepairAttempted) {
+    $script:OcrCompatibilityRepairAttempted = $true
+    Write-InstallLog "OCR DLL import failed; replacing the moving native dependency stack with the Windows 10 compatible stack."
+    if ((Install-OcrCompatibilityPackages -PythonPath $PythonPath) -and (Test-OcrPythonImports -PythonPath $PythonPath)) {
+      Write-InstallLog "OCR import validation passed with the Windows compatibility stack."
+      return $true
+    }
+    Write-InstallLog "OCR compatibility stack did not resolve the DLL import; trying the official Microsoft runtime repair."
+  }
+
   if ($script:VisualCppRuntimeRepairAttempted -or !(Test-MissingVisualCppRuntime)) {
     return $false
   }
@@ -451,6 +479,19 @@ function Install-OcrPackagesWithPip {
   return $exitCode -eq 0
 }
 
+function Install-OcrCompatibilityPackages {
+  param([Parameter(Mandatory = $true)][string]$PythonPath)
+  Write-InstallLog "Installing the pinned OCR Windows compatibility stack."
+  $commonArguments = @("-m", "pip", "install", "--upgrade", "--force-reinstall") + $OcrCompatibilityPackageRequirements
+  $exitCode = Invoke-NativeCommand -FilePath $PythonPath -Arguments ($commonArguments + @("-i", $TencentPipIndexUrl, "--extra-index-url", $PypiFallbackIndexUrl))
+  if ($exitCode -eq 0) {
+    return $true
+  }
+  Write-InstallLog "Tencent PyPI compatibility install failed; retrying with PyPI only."
+  $exitCode = Invoke-NativeCommand -FilePath $PythonPath -Arguments ($commonArguments + @("-i", $PypiFallbackIndexUrl))
+  return $exitCode -eq 0
+}
+
 function Setup-PythonEnvironment {
   $venvPython = Join-Path $VenvDir "Scripts\python.exe"
   if ((Test-Path -LiteralPath $venvPython) -and (Test-OcrPythonReady -PythonPath $venvPython)) {
@@ -468,6 +509,7 @@ function Setup-PythonEnvironment {
     }
     Write-InstallLog "Existing Python OCR setup failed; falling back to pinned portable Python."
     Remove-DirectoryStrict -Path $VenvDir
+    $script:OcrCompatibilityRepairAttempted = $false
   }
 
   $python = Install-PortablePython

--- a/tests/plugin-marketplace-package.test.js
+++ b/tests/plugin-marketplace-package.test.js
@@ -109,6 +109,14 @@ assert.ok(windowsOcrInstaller.includes('function Install-MicrosoftVisualCppRunti
 assert.ok(windowsOcrInstaller.includes('Get-AuthenticodeSignature'), 'Downloaded Microsoft runtime installer must be signature-verified before execution');
 assert.ok(windowsOcrInstaller.includes('-Verb RunAs'), 'Visual C++ runtime repair must request Windows elevation explicitly');
 assert.ok(windowsOcrInstaller.includes('Visual C++ runtime repair finished; retrying OCR import validation.'), 'Windows OCR installer must retry validation after runtime repair');
+assert.ok(windowsOcrInstaller.includes('onnxruntime==1.27.0'), 'Windows OCR primary native stack must be reproducibly pinned');
+assert.ok(windowsOcrInstaller.includes('numpy==2.5.1'), 'Windows OCR primary NumPy version must be reproducibly pinned');
+assert.ok(windowsOcrInstaller.includes('opencv-python==5.0.0.93'), 'Windows OCR primary OpenCV version must be reproducibly pinned');
+assert.ok(windowsOcrInstaller.includes('onnxruntime==1.20.1'), 'Windows OCR installer must pin a Windows 10 compatible ONNX Runtime fallback');
+assert.ok(windowsOcrInstaller.includes('numpy==1.26.4'), 'Windows OCR compatibility fallback must pin NumPy instead of resolving a moving native stack');
+assert.ok(windowsOcrInstaller.includes('opencv-python==4.10.0.84'), 'Windows OCR compatibility fallback must pin OpenCV instead of resolving a moving native stack');
+assert.ok(windowsOcrInstaller.includes('function Install-OcrCompatibilityPackages'), 'Windows OCR installer must automatically retry DLL failures with the compatible native stack');
+assert.ok(windowsOcrInstaller.includes('--force-reinstall'), 'Windows OCR compatibility repair must replace the failed native packages completely');
 assert.ok(windowsOcrInstaller.includes('$StagingVenvDir'), 'Windows OCR repair must build in a staging venv');
 assert.ok(windowsOcrInstaller.includes('$BackupVenvDir'), 'Windows OCR repair must keep only a short-lived rollback venv');
 assert.ok(windowsOcrInstaller.includes('$PendingSwitchPath'), 'Windows OCR repair must support restart-time activation when files are locked');


### PR DESCRIPTION
Pin Windows OCR native dependencies and automatically retry DLL failures with the verified Windows 10 compatibility stack. Tests: plugin regression, package gate, governance 122/122, PowerShell parse, real RapidOCR initialization.