### PR TITLE
Release 1.3.55: binding and transcription fixes

### DIFF
--- a/docs/task-cards/plugin-bind-transcription-001.md
+++ b/docs/task-cards/plugin-bind-transcription-001.md
@@ -12,7 +12,7 @@
 - 父主线：H2-002
 - 分支：codex/plugin-bind-transcription
 - Worktree：.worktrees/plugin-bind-transcription
-- 文件所有权：docs/task-cards/plugin-bind-transcription-001.md；docs/superpowers/specs/2026-07-23-plugin-bind-transcription-design.md；docs/superpowers/plans/2026-07-23-plugin-bind-transcription.md；obsidian-plugin/wechat-inbox-sync/main.js；obsidian-plugin/wechat-inbox-sync/local-asr/install-local-asr.ps1；obsidian-plugin/wechat-inbox-sync/local-asr/install-local-asr-macos.sh；tests/plugin-main-ai.test.js；tests/plugin-marketplace-package.test.js
+- 文件所有权：docs/task-cards/plugin-bind-transcription-001.md；docs/superpowers/specs/2026-07-23-plugin-bind-transcription-design.md；docs/superpowers/plans/2026-07-23-plugin-bind-transcription.md；obsidian-plugin/wechat-inbox-sync/main.js；obsidian-plugin/wechat-inbox-sync/local-asr/install-local-asr.ps1；obsidian-plugin/wechat-inbox-sync/local-asr/install-local-asr-macos.sh；scripts/deploy-local-components.ps1；tests/plugin-main-ai.test.js；tests/plugin-marketplace-package.test.js；tests/release-governance.test.js
 - 环境或发布链路占用：无
 
 ## 目标

--- a/scripts/deploy-local-components.ps1
+++ b/scripts/deploy-local-components.ps1
@@ -14,6 +14,7 @@ $PublicRoot = 'https://he02-d8gebzv050ed6c4ef-d350b93bf-1357443479.tcloudbaseapp
 $PublicManifestPath = 'local-components/manifest.json'
 $PublicFetchTimeoutSeconds = 20
 $PublicFetchAttempts = 5
+$CloudListAttempts = 3
 $ImmutableRecheckDelayMilliseconds = 500
 $RepoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
 $PluginRoot = Join-Path $RepoRoot 'obsidian-plugin\wechat-inbox-sync'
@@ -114,7 +115,7 @@ function Invoke-JsonExternalCommand {
             ''
         })
         if ($exitCode -ne 0) {
-            throw "$Label failed with exit code $exitCode. stderr: $stderrText"
+            throw "$Label failed with exit code $exitCode. stdout: $stdoutText stderr: $stderrText"
         }
         return $stdoutText
     }
@@ -406,9 +407,28 @@ function Get-RemoteObjectState {
         [string]$ResolvedTcbPath,
         [string]$RemotePath
     )
-    $jsonOutput = Invoke-JsonExternalCommand -FilePath $ResolvedTcbPath `
-        -Arguments @('hosting', 'list', $RemotePath, '--json', '-e', $CloudBaseEnvironment) `
-        -Label "CloudBase hosting list for $RemotePath"
+    $jsonOutput = $null
+    $lastError = $null
+    for ($attempt = 1; $attempt -le $CloudListAttempts; $attempt++) {
+        try {
+            $jsonOutput = Invoke-JsonExternalCommand -FilePath $ResolvedTcbPath `
+                -Arguments @('hosting', 'list', $RemotePath, '--json', '-e', $CloudBaseEnvironment) `
+                -Label "CloudBase hosting list for $RemotePath"
+            break
+        }
+        catch {
+            if (-not (Test-RetryableCloudBaseListFailure -Failure $_)) {
+                throw
+            }
+            $lastError = $_
+            if ($attempt -lt $CloudListAttempts) {
+                Start-Sleep -Seconds ([Math]::Pow(2, $attempt - 1))
+            }
+        }
+    }
+    if ($null -eq $jsonOutput) {
+        throw "CloudBase hosting list for $RemotePath failed after $CloudListAttempts attempts: $lastError"
+    }
     $document = Find-JsonValue -Text $jsonOutput
     Assert-CloudListDocument -Document $document
     $matches = New-Object System.Collections.ArrayList
@@ -420,6 +440,12 @@ function Get-RemoteObjectState {
         Exists = ($matches.Count -eq 1)
         Object = $(if ($matches.Count -eq 1) { $matches[0] } else { $null })
     }
+}
+
+function Test-RetryableCloudBaseListFailure {
+    param([System.Management.Automation.ErrorRecord]$Failure)
+    $message = [string]$Failure
+    return $message -match '(?i)\b(ETIMEDOUT|ECONNRESET|ECONNREFUSED|EAI_AGAIN|ENOTFOUND|network|timed out|timeout)\b|请求超时|网络'
 }
 
 function Publish-CloudObject {

--- a/scripts/deploy-local-components.ps1
+++ b/scripts/deploy-local-components.ps1
@@ -445,7 +445,7 @@ function Get-RemoteObjectState {
 function Test-RetryableCloudBaseListFailure {
     param([System.Management.Automation.ErrorRecord]$Failure)
     $message = [string]$Failure
-    return $message -match '(?i)\b(ETIMEDOUT|ECONNRESET|ECONNREFUSED|EAI_AGAIN|ENOTFOUND|network|timed out|timeout)\b|请求超时|网络'
+    return $message -match '(?i)\b(ETIMEDOUT|ECONNRESET|ECONNREFUSED|EAI_AGAIN|ENOTFOUND|network|timed out|timeout)\b|\u8BF7\u6C42\u8D85\u65F6|\u7F51\u7EDC'
 }
 
 function Publish-CloudObject {

--- a/tests/release-governance.test.js
+++ b/tests/release-governance.test.js
@@ -1311,6 +1311,13 @@ test('successful native commands may emit progress on stderr under ErrorActionPr
   assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
 });
 
+test('CloudBase retry classifier is ASCII-only for Windows PowerShell source portability', () => {
+  const deployerSource = readText(relativePaths.deployScript);
+  const classifier = deployerSource.match(/function Test-RetryableCloudBaseListFailure \{[\s\S]*?\n\}/);
+  assert.ok(classifier, 'CloudBase retry classifier must exist');
+  assert.doesNotMatch(classifier[0], /[\u4e00-\u9fff]/, 'retry classifier must not rely on the source-file code page');
+});
+
 test('the controlled deployer parses in Windows PowerShell and its real dry run needs no tcb or network', {
   skip: requiresWindowsPowerShell,
 }, () => {

--- a/tests/release-governance.test.js
+++ b/tests/release-governance.test.js
@@ -1202,6 +1202,92 @@ test('CloudBase JSON commands keep stderr separate and pass exact hosting-list a
   );
 });
 
+test('CloudBase exact-list probes retry a transient CLI failure before reporting absence', {
+  skip: requiresWindowsPowerShell,
+}, (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'fake-tcb-transient-list-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const fakeTcbPath = path.join(directory, 'fake-tcb.cmd');
+  const counterPath = path.join(directory, 'attempted.txt');
+  fs.writeFileSync(fakeTcbPath, [
+    '@echo off',
+    `if exist "${counterPath}" goto success`,
+    `> "${counterPath}" echo first-attempt`,
+    '>&2 echo request timed out',
+    'exit /b 1',
+    ':success',
+    'echo {"data":[],"meta":{"requestId":"fixture"}}',
+    'exit /b 0',
+    '',
+  ].join('\r\n'), 'utf8');
+  const encodedTcb = Buffer.from(fakeTcbPath, 'utf16le').toString('base64');
+  const result = runDeployerPowerShellProbe([
+    `$fakeTcb=[Text.Encoding]::Unicode.GetString([Convert]::FromBase64String('${encodedTcb}'))`,
+    "$state=Get-RemoteObjectState -ResolvedTcbPath $fakeTcb -RemotePath 'target/object'",
+    'if($state.Exists){throw "empty list reported an object"}',
+  ].join(';'));
+  assertNormalExit(result, 'fake tcb transient-list probe');
+  assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+  assert.equal(fs.existsSync(counterPath), true, 'fixture must prove the first CLI call failed');
+});
+
+test('CloudBase exact-list probes classify transient errors emitted on CLI stdout', {
+  skip: requiresWindowsPowerShell,
+}, (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'fake-tcb-stdout-timeout-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const fakeTcbPath = path.join(directory, 'fake-tcb.cmd');
+  const counterPath = path.join(directory, 'attempted.txt');
+  fs.writeFileSync(fakeTcbPath, [
+    '@echo off',
+    `if exist "${counterPath}" goto success`,
+    `> "${counterPath}" echo first-attempt`,
+    'echo {"error":{"message":"request timed out"}}',
+    'exit /b 1',
+    ':success',
+    'echo {"data":[],"meta":{"requestId":"fixture"}}',
+    'exit /b 0',
+    '',
+  ].join('\r\n'), 'utf8');
+  const encodedTcb = Buffer.from(fakeTcbPath, 'utf16le').toString('base64');
+  const result = runDeployerPowerShellProbe([
+    `$fakeTcb=[Text.Encoding]::Unicode.GetString([Convert]::FromBase64String('${encodedTcb}'))`,
+    "$state=Get-RemoteObjectState -ResolvedTcbPath $fakeTcb -RemotePath 'target/object'",
+    'if($state.Exists){throw "empty list reported an object"}',
+  ].join(';'));
+  assertNormalExit(result, 'fake tcb stdout-timeout probe');
+  assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+  assert.equal(fs.existsSync(counterPath), true, 'fixture must prove the first CLI call failed');
+});
+
+test('CloudBase exact-list probes do not retry a permanent CLI failure', {
+  skip: requiresWindowsPowerShell,
+}, (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'fake-tcb-permanent-list-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const fakeTcbPath = path.join(directory, 'fake-tcb.cmd');
+  const markerPath = path.join(directory, 'first-attempt.txt');
+  fs.writeFileSync(fakeTcbPath, [
+    '@echo off',
+    `if exist "${markerPath}" goto retried`,
+    `> "${markerPath}" echo first-attempt`,
+    '>&2 echo permission denied',
+    'exit /b 1',
+    ':retried',
+    '>&2 echo permanent failure was retried',
+    'exit /b 9',
+    '',
+  ].join('\r\n'), 'utf8');
+  const encodedTcb = Buffer.from(fakeTcbPath, 'utf16le').toString('base64');
+  const result = runDeployerPowerShellProbe([
+    `$fakeTcb=[Text.Encoding]::Unicode.GetString([Convert]::FromBase64String('${encodedTcb}'))`,
+    "$null=Get-RemoteObjectState -ResolvedTcbPath $fakeTcb -RemotePath 'target/object'",
+  ].join(';'));
+  assert.notEqual(result.status, 0, 'permanent CLI failure must fail the probe');
+  assert.doesNotMatch(`${result.stdout}${result.stderr}`, /permanent failure was retried/i);
+  assert.equal(fs.existsSync(markerPath), true, 'fixture must prove the first CLI call ran');
+});
+
 test('successful native commands may emit progress on stderr under ErrorActionPreference Stop', {
   skip: requiresWindowsPowerShell,
 }, (t) => {


### PR DESCRIPTION
Release 1.3.55 candidate plus a guarded retry for transient CloudBase component-probe timeouts. The retry affects only read-only hosting list probes; deployments still fail closed for permanent errors.