### PR TITLE
Fix macOS ASR CPU fallback installer

### DIFF
--- a/obsidian-plugin/wechat-inbox-sync/local-asr/install-local-asr-macos.sh
+++ b/obsidian-plugin/wechat-inbox-sync/local-asr/install-local-asr-macos.sh
@@ -5,7 +5,7 @@ INSTALL_ROOT="$HOME/.wechat-inbox-local-asr"
 TEMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/wechat-inbox-local-asr-install.XXXXXX")"
 CACHE_ROOT="$INSTALL_ROOT/cache"
 INSTALL_STATE_PATH="$INSTALL_ROOT/.install-state.json"
-INSTALLER_SCRIPT_VERSION="1.3.8"
+INSTALLER_SCRIPT_VERSION="1.3.9"
 DOWNLOAD_LOW_SPEED_LIMIT=10240
 DOWNLOAD_LOW_SPEED_TIME=180
 LOCK_DIR="$INSTALL_ROOT/.install.lock"
@@ -319,8 +319,9 @@ WHISPER_CPP_BIN="$whisper_target"
 GGML_METAL_RESOURCES_DIR="$metal_resources_dir"
 if [ -n "\$GGML_METAL_RESOURCES_DIR" ] && [ -f "\$GGML_METAL_RESOURCES_DIR/ggml-metal.metal" ]; then
   export GGML_METAL_PATH_RESOURCES="\$GGML_METAL_RESOURCES_DIR"
+  exec "\$WHISPER_CPP_BIN" "\$@"
 fi
-exec "\$WHISPER_CPP_BIN" "\$@"
+exec "\$WHISPER_CPP_BIN" --no-gpu "\$@"
 SCRIPT
   chmod +x "$INSTALL_ROOT/bin/whisper-cli"
 }
@@ -692,8 +693,8 @@ mkdir -p "$INSTALL_ROOT/bin" "$INSTALL_ROOT/models" "$CACHE_ROOT"
 
 # Primary path: uv → Python → pip packages.
 # Returns 2 if uv pip install failed but Homebrew is available as fallback.
-setup_python_and_packages
-setup_rc=$?
+setup_rc=0
+setup_python_and_packages || setup_rc=$?
 
 if [ $setup_rc -eq 2 ]; then
   # uv pip install failed, but Homebrew is available.
@@ -736,16 +737,6 @@ FFMPEG_BIN="$(find_command ffmpeg || true)"
 if [ -z "$FFMPEG_BIN" ]; then
   echo "ffmpeg was not found after installation." >&2
   exit 1
-fi
-
-WHISPER_METAL_RESOURCES="$(find_metal_resources_dir "$WHISPER_BIN" || true)"
-if [ -z "$WHISPER_METAL_RESOURCES" ] && command -v brew >/dev/null 2>&1; then
-  echo "Metal resources not found for current whisper; trying Homebrew whisper-cpp fallback."
-  brew_install_formula whisper-cpp
-  BREW_WHISPER_BIN="$(find_homebrew_whisper_command || true)"
-  if [ -n "$BREW_WHISPER_BIN" ]; then
-    WHISPER_BIN="$BREW_WHISPER_BIN"
-  fi
 fi
 
 # Refresh the whisper wrapper so existing installs pick up Metal resource discovery.

--- a/obsidian-plugin/wechat-inbox-sync/local-components-manifest.json
+++ b/obsidian-plugin/wechat-inbox-sync/local-components-manifest.json
@@ -4,8 +4,8 @@
     {
       "id": "asr-macos-installer",
       "sourcePath": "local-asr/install-local-asr-macos.sh",
-      "sha256": "4c6e2546564e03f75aac28298fdb5254bb4a5dfcd95f97f8dcc516bfff0e8c61",
-      "immutablePath": "local-components/by-sha256/4c6e2546564e03f75aac28298fdb5254bb4a5dfcd95f97f8dcc516bfff0e8c61/install-local-asr-macos.sh",
+      "sha256": "364c329fd4f07aea1c18d8d4f6d0abd2a49b1e77c8f461268d9bd5d041526bcc",
+      "immutablePath": "local-components/by-sha256/364c329fd4f07aea1c18d8d4f6d0abd2a49b1e77c8f461268d9bd5d041526bcc/install-local-asr-macos.sh",
       "compatibilityAlias": "local-asr/common/install-local-asr-macos.sh"
     },
     {

--- a/tests/plugin-macos-asr-installer.test.js
+++ b/tests/plugin-macos-asr-installer.test.js
@@ -1,0 +1,186 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const root = path.resolve(__dirname, '..');
+const installerPath = path.join(
+  root,
+  'obsidian-plugin',
+  'wechat-inbox-sync',
+  'local-asr',
+  'install-local-asr-macos.sh',
+);
+const installer = fs.readFileSync(installerPath, 'utf8');
+
+function extractShellFunction(source, functionName, nextFunctionName) {
+  const startMarker = `${functionName}() {`;
+  const endMarker = `\n\n${nextFunctionName}() {`;
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker, start);
+  assert.ok(start >= 0, `missing shell function: ${functionName}`);
+  assert.ok(end > start, `cannot find end of shell function: ${functionName}`);
+  return source.slice(start, end);
+}
+
+function extractShellSection(source, startMarker, endMarker) {
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker, start);
+  assert.ok(start >= 0, `missing shell section start: ${startMarker}`);
+  assert.ok(end > start, `missing shell section end: ${endMarker}`);
+  return source.slice(start, end);
+}
+
+function findBash() {
+  const candidates = [
+    process.env.BASH_PATH,
+    process.platform === 'win32' ? 'C:\\Program Files\\Git\\bin\\bash.exe' : '/bin/bash',
+    'bash',
+  ].filter(Boolean);
+  for (const candidate of candidates) {
+    const probe = spawnSync(candidate, ['--version'], { encoding: 'utf8' });
+    if (!probe.error && probe.status === 0) return candidate;
+  }
+  throw new Error('bash is required for the macOS ASR installer behavior test');
+}
+
+function runWrapperHarness({ withMetalResources }) {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wechat-inbox-macos-asr-test-'));
+  try {
+    const harnessPath = path.join(tempRoot, 'harness.sh');
+    const writeWrapperFunction = extractShellFunction(
+      installer,
+      'write_whisper_wrapper',
+      'find_homebrew_whisper_command',
+    );
+    const metalFixture = withMetalResources
+      ? [
+          'METAL_DIR="$TEST_ROOT/metal"',
+          'mkdir -p "$METAL_DIR"',
+          'touch "$METAL_DIR/ggml-metal.metal"',
+          'find_metal_resources_dir() { printf "%s\\n" "$METAL_DIR"; }',
+        ].join('\n')
+      : 'find_metal_resources_dir() { return 0; }';
+
+    fs.writeFileSync(
+      harnessPath,
+      [
+        '#!/usr/bin/env bash',
+        'set -euo pipefail',
+        'TEST_ROOT="$(cd "$(dirname "$0")" && pwd)"',
+        'INSTALL_ROOT="$TEST_ROOT/install"',
+        'mkdir -p "$INSTALL_ROOT/bin"',
+        'FAKE_WHISPER="$TEST_ROOT/fake-whisper"',
+        'cat > "$FAKE_WHISPER" <<\'SCRIPT\'',
+        '#!/usr/bin/env bash',
+        'printf "metal=%s\\n" "${GGML_METAL_PATH_RESOURCES:-}" > "$TEST_ROOT/result.txt"',
+        'printf "arg=%s\\n" "$@" >> "$TEST_ROOT/result.txt"',
+        'SCRIPT',
+        'chmod +x "$FAKE_WHISPER"',
+        'export TEST_ROOT',
+        metalFixture,
+        writeWrapperFunction,
+        'write_whisper_wrapper "$FAKE_WHISPER"',
+        '"$INSTALL_ROOT/bin/whisper-cli" -m model.bin -f input.wav',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const run = spawnSync(findBash(), [harnessPath], { encoding: 'utf8' });
+    assert.strictEqual(
+      run.status,
+      0,
+      `wrapper harness failed:\nstdout=${run.stdout}\nstderr=${run.stderr}`,
+    );
+    return fs.readFileSync(path.join(tempRoot, 'result.txt'), 'utf8');
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+const cpuResult = runWrapperHarness({ withMetalResources: false });
+assert.match(
+  cpuResult,
+  /^metal=\r?\narg=--no-gpu\r?$/m,
+  'missing Metal resources must make the official whisper wrapper select CPU mode',
+);
+assert.match(cpuResult, /^arg=-m\r?\narg=model\.bin\r?\narg=-f\r?\narg=input\.wav\r?$/m);
+
+const metalResult = runWrapperHarness({ withMetalResources: true });
+assert.match(metalResult, /^metal=.+\/metal\r?$/m);
+assert.strictEqual(
+  metalResult.includes('arg=--no-gpu'),
+  false,
+  'available Metal resources must keep hardware acceleration enabled',
+);
+assert.match(metalResult, /^arg=-m\r?\narg=model\.bin\r?\narg=-f\r?\narg=input\.wav\r?$/m);
+
+function runSetupOrchestrationHarness(setupReturnCode) {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wechat-inbox-macos-asr-setup-test-'));
+  try {
+    const harnessPath = path.join(tempRoot, 'harness.sh');
+    const setupOrchestration = extractShellSection(
+      installer,
+      '# Primary path: uv → Python → pip packages.',
+      '# Locate whisper binary.',
+    );
+    fs.writeFileSync(
+      harnessPath,
+      [
+        '#!/usr/bin/env bash',
+        'set -euo pipefail',
+        'TEST_ROOT="$(cd "$(dirname "$0")" && pwd)"',
+        `setup_python_and_packages() { return ${setupReturnCode}; }`,
+        'brew_install_formula() { printf "%s\\n" "$1" >> "$TEST_ROOT/brew.log"; }',
+        setupOrchestration,
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+    const run = spawnSync(findBash(), [harnessPath], { encoding: 'utf8' });
+    const brewLogPath = path.join(tempRoot, 'brew.log');
+    return {
+      ...run,
+      brewLog: fs.existsSync(brewLogPath) ? fs.readFileSync(brewLogPath, 'utf8') : '',
+    };
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+const primarySetup = runSetupOrchestrationHarness(0);
+assert.strictEqual(primarySetup.status, 0);
+assert.strictEqual(primarySetup.brewLog, '');
+
+const homebrewFallbackSetup = runSetupOrchestrationHarness(2);
+assert.strictEqual(
+  homebrewFallbackSetup.status,
+  0,
+  'primary package failure with Homebrew available must reach the last-resort fallback',
+);
+assert.strictEqual(homebrewFallbackSetup.brewLog, 'ffmpeg\nwhisper-cpp\n');
+
+const unavailableFallbackSetup = runSetupOrchestrationHarness(1);
+assert.strictEqual(unavailableFallbackSetup.status, 1);
+assert.strictEqual(unavailableFallbackSetup.brewLog, '');
+
+assert.strictEqual(
+  installer.includes(
+    'Metal resources not found for current whisper; trying Homebrew whisper-cpp fallback.',
+  ),
+  false,
+  'an already installed whisper must not require Homebrew only to repair optional Metal resources',
+);
+assert.ok(
+  installer.includes('if [ $setup_rc -eq 2 ]; then')
+    && installer.includes('brew_install_formula whisper-cpp'),
+  'Homebrew must remain available only as the last fallback when the primary ASR package install fails',
+);
+assert.ok(
+  installer.includes('run_or_skip_local_asr_validation'),
+  'the installer must retain real inference validation before reporting success',
+);
+
+console.log('plugin macOS ASR installer behavior tests passed');

--- a/tests/plugin-main-ai.test.js
+++ b/tests/plugin-main-ai.test.js
@@ -122,7 +122,7 @@ const nonTransactionalWindowsAsrInstallerSource = windowsAsrInstallerSource
   .replaceAll('Restore-TranscribeScriptUpdate', 'Restore-LegacyTranscribeScriptUpdate')
   .replaceAll('Complete-TranscribeScriptUpdate', 'Complete-LegacyTranscribeScriptUpdate');
 const staleMacAsrInstallerSource = macAsrInstallerSource
-  .replace('INSTALLER_SCRIPT_VERSION="1.3.8"', 'INSTALLER_SCRIPT_VERSION="1.3.7"');
+  .replace('INSTALLER_SCRIPT_VERSION="1.3.9"', 'INSTALLER_SCRIPT_VERSION="1.3.7"');
 const promptedMacAsrInstallerSource = macAsrInstallerSource
   .replace('TRANSCRIPT_QUALITY_GUARD_VERSION="repeat-guard-v2"', 'SIMPLIFIED_PROMPT="请输入简体中文"\n--prompt "$SIMPLIFIED_PROMPT"');
 const legacyUvOnlyMacAsrInstallerSource = macAsrInstallerSource

--- a/tests/plugin-marketplace-package.test.js
+++ b/tests/plugin-marketplace-package.test.js
@@ -749,7 +749,7 @@ assert.ok(macInstaller.includes('ASR_WHEELHOUSE_BASE_URL="${TENCENT_BASE_URL}/lo
 assert.ok(macInstaller.includes('ASR_PACKAGE_REQUIREMENTS=("whisper.cpp-cli==0.0.3" "imageio-ffmpeg==0.6.0")'));
 assert.ok(macInstaller.includes('install_asr_packages "$VENV_PYTHON"'));
 assert.ok(macInstaller.includes('INSTALL_STATE_PATH="$INSTALL_ROOT/.install-state.json"'));
-assert.ok(macInstaller.includes('INSTALLER_SCRIPT_VERSION="1.3.8"'));
+assert.ok(macInstaller.includes('INSTALLER_SCRIPT_VERSION="1.3.9"'));
 assert.ok(macInstaller.includes('DOWNLOAD_LOW_SPEED_LIMIT=10240'));
 assert.ok(macInstaller.includes('DOWNLOAD_LOW_SPEED_TIME=180'));
 assert.ok(macInstaller.includes('--speed-limit "$DOWNLOAD_LOW_SPEED_LIMIT"'));
@@ -786,6 +786,13 @@ assert.ok(
 );
 assert.ok(macInstaller.includes('brew_install_formula whisper-cpp'));
 assert.strictEqual(macInstaller.includes('brew reinstall whisper-cpp'), false);
+assert.ok(macInstaller.includes('exec "\\$WHISPER_CPP_BIN" --no-gpu "\\$@"'));
+assert.strictEqual(
+  macInstaller.includes(
+    'Metal resources not found for current whisper; trying Homebrew whisper-cpp fallback.',
+  ),
+  false,
+);
 assert.ok(macInstaller.includes('hf-mirror.com/ggerganov/whisper.cpp'));
 assert.ok(
   macInstaller.indexOf('TENCENT_MODEL_URL=') <


### PR DESCRIPTION
Fix macOS 26.5 installation when optional Metal resources are absent.

- use whisper.cpp --no-gpu CPU fallback
- keep Homebrew only as reachable last-resort fallback
- add executable installer behavior regression tests
- update canonical local-component manifest hash

No plugin version, tag, or Release change.