### PR TITLE
fix: stabilize root release mirror line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
+main.js text eol=lf
+manifest.json text eol=lf
+styles.css text eol=lf
+versions.json text eol=lf
 obsidian-plugin/wechat-inbox-sync/main.js text eol=lf
 obsidian-plugin/wechat-inbox-sync/src/main.js text eol=lf
 obsidian-plugin/wechat-inbox-sync/local-asr/install-local-asr.ps1 text eol=lf


### PR DESCRIPTION
修复 Windows 干净 checkout 中根发布镜像被自动转换为 CRLF、导致逐字节镜像门禁误报漂移的问题。

- 仅为根 main.js / manifest.json / styles.css / versions.json 增加 `text eol=lf`
- 对应完整 `LOOSE_ASSETS`，无遗漏
- 不修改插件业务代码或发布资产内容
- fresh checkout 镜像校验通过
- 候选治理 24 pass / 0 fail / 1 权限 skip
- 发布治理 126/126
- 独立审查 P0/P1/P2 = 0