### PR TITLE
fix: allow release identity checks for bundled PDF.js

### DIFF
--- a/scripts/check-plugin-release-identity.js
+++ b/scripts/check-plugin-release-identity.js
@@ -41,6 +41,9 @@ const REPOSITORY = 'wechat-inbox-sync';
 const API_ORIGIN = 'https://api.github.com';
 const GITHUB_API_TIMEOUT_MS = 20000;
 const GIT_TIMEOUT_MS = 30000;
+// PDF.js makes the bundled plugin exceed Node's default 1 MiB exec buffer.
+// Keep trusted git reads bounded while allowing a legitimate release asset.
+const MAX_TRUSTED_GIT_SHOW_BYTES = 16 * 1024 * 1024;
 const MAX_REDIRECTS = 5;
 const ALLOWED_DOWNLOAD_HOSTS = new Set([
   'github.com',
@@ -357,6 +360,7 @@ function gitShowBytes(trustedCommit, relativePath) {
         shell: false,
         stdio: ['ignore', 'pipe', 'pipe'],
         timeout: GIT_TIMEOUT_MS,
+        maxBuffer: MAX_TRUSTED_GIT_SHOW_BYTES,
       },
     );
   } catch (error) {
@@ -468,6 +472,7 @@ function verifyPromotionReceiptAtCommit(tag, trustedCommit) {
         shell: false,
         stdio: ['ignore', 'pipe', 'pipe'],
         timeout: GIT_TIMEOUT_MS,
+        maxBuffer: MAX_TRUSTED_GIT_SHOW_BYTES,
       },
     );
   } catch (error) {

--- a/tests/plugin-release-identity.test.js
+++ b/tests/plugin-release-identity.test.js
@@ -753,6 +753,8 @@ test('production CLI exposes only fixed prepublish/postpublish modes and no comm
   assert.match(cli, /collectLocalInputs\(tag,\s*\{\s*requireLocalAnnotatedTag:\s*false\s*\}\)/);
   assert.match(cli, /verifyPublishedAssetBytes\(lastRelease,\s*tag,\s*finalCommit\)/);
   assert.match(cli, /\['show',\s*`\$\{trustedCommit\}:/);
+  assert.match(cli, /const MAX_TRUSTED_GIT_SHOW_BYTES = 16 \* 1024 \* 1024/);
+  assert.match(cli, /maxBuffer:\s*MAX_TRUSTED_GIT_SHOW_BYTES/);
   assert.match(cli, /verifyPublishedAssetBytes[\s\S]*probeStableRemoteTag\(tag,\s*4,/);
 });
 


### PR DESCRIPTION
Release-governance-only fix: allow the bounded trusted git read used by identity verification to handle the bundled PDF.js asset. No plugin behavior or version change. Local checks: plugin-release-identity 26/26; release-governance 126/126.