### PR TITLE
Fix local component prompt dismissal for 1.3.124

### DIFF
--- a/main.js
+++ b/main.js
@@ -19975,14 +19975,24 @@ var _LocalComponentInstallConfirmModal = class _LocalComponentInstallConfirmModa
     this.message.split("\n").map((line) => line.trim()).filter(Boolean).forEach((line) => contentEl.createEl("p", { text: line }));
     const buttonRow = contentEl.createDiv({ cls: "wechat-inbox-sync-modal-actions" });
     const confirmButton = buttonRow.createEl("button", { text: "开始安装/修复" });
+    confirmButton.type = "button";
     if (typeof confirmButton.addClass === "function") {
       confirmButton.addClass("mod-cta");
     } else {
       confirmButton.className = `${confirmButton.className || ""} mod-cta`.trim();
     }
-    confirmButton.addEventListener("click", () => this.finish(true));
+    confirmButton.addEventListener("click", (event) => {
+      if (event && typeof event.preventDefault === "function") event.preventDefault();
+      if (event && typeof event.stopPropagation === "function") event.stopPropagation();
+      this.finish(true);
+    });
     const laterButton = buttonRow.createEl("button", { text: "稍后再试" });
-    laterButton.addEventListener("click", () => this.finish(false));
+    laterButton.type = "button";
+    laterButton.addEventListener("click", (event) => {
+      if (event && typeof event.preventDefault === "function") event.preventDefault();
+      if (event && typeof event.stopPropagation === "function") event.stopPropagation();
+      this.finish(false);
+    });
   }
   onClose() {
     if (this.contentEl) this.contentEl.empty();
@@ -22248,6 +22258,26 @@ var _WechatObsidianInboxPlugin = class _WechatObsidianInboxPlugin extends Plugin
       ocrStatus
     };
   }
+  isLocalComponentInstallPromptSnoozed(reason = "") {
+    if (reason === "manual-refresh") return false;
+    const snoozedUntil = Date.parse(this.settings.proSetupInstallPromptSnoozedUntil || "");
+    return Number.isFinite(snoozedUntil) && Date.now() < snoozedUntil;
+  }
+  async snoozeLocalComponentInstallPrompt(now = Date.now()) {
+    const snoozedUntil = new Date(now + PRO_SETUP_PROMPT_COOLDOWN_MS).toISOString();
+    await this.saveSettings({
+      ...this.settings,
+      proSetupInstallPromptSnoozedUntil: snoozedUntil
+    });
+    return snoozedUntil;
+  }
+  async clearLocalComponentInstallPromptSnooze() {
+    if (!this.settings.proSetupInstallPromptSnoozedUntil) return;
+    await this.saveSettings({
+      ...this.settings,
+      proSetupInstallPromptSnoozedUntil: ""
+    });
+  }
   async refreshProAndMaybePromptLocalComponentInstall(options = {}) {
     const reason = options.reason || "settings-open";
     const now = Date.now();
@@ -22285,12 +22315,25 @@ var _WechatObsidianInboxPlugin = class _WechatObsidianInboxPlugin extends Plugin
       };
       const shouldInstallMissingComponents = options.installMissingComponents === true || reason === "manual-refresh";
       if (shouldInstallMissingComponents && refreshPlan.hasRequiredChanges) {
+        if (this.isLocalComponentInstallPromptSnoozed(reason)) {
+          status = {
+            ...status,
+            localComponentInstallSkipped: {
+              reason: "snoozed",
+              snoozedUntil: this.settings.proSetupInstallPromptSnoozedUntil,
+              ...refreshPlan
+            }
+          };
+          return status;
+        }
         const accepted = await this.confirmLocalComponentInstall(status, reason, readiness);
         if (!accepted) {
+          const snoozedUntil = await this.snoozeLocalComponentInstallPrompt(now);
           status = {
             ...status,
             localComponentInstallSkipped: {
               reason: "user-declined",
+              snoozedUntil,
               ...refreshPlan
             }
           };
@@ -22321,6 +22364,7 @@ var _WechatObsidianInboxPlugin = class _WechatObsidianInboxPlugin extends Plugin
             localComponentReadiness: readiness,
             localComponentRefreshPlan: refreshPlan
           };
+          await this.clearLocalComponentInstallPromptSnooze();
         } catch (error) {
           const failedReadiness = this.getLocalTranscriptionComponentReadiness();
           status = {
@@ -22466,16 +22510,22 @@ var _WechatObsidianInboxPlugin = class _WechatObsidianInboxPlugin extends Plugin
       ready: false,
       missingComponents
     };
-    const accepted = await this.confirmLocalComponentInstall(status, options.reason || "first-use", requiredReadiness);
+    const promptReason = options.reason || "first-use";
+    if (this.isLocalComponentInstallPromptSnoozed(promptReason)) {
+      throw new Error(`${featureName}需要先安装本地转写组件；你已选择稍后再试，请在插件设置里点击“刷新权限”后安装/修复。`);
+    }
+    const accepted = await this.confirmLocalComponentInstall(status, promptReason, requiredReadiness);
     if (!accepted) {
+      await this.snoozeLocalComponentInstallPrompt();
       throw new Error(`${featureName}需要先安装本地转写组件。`);
     }
     await this.installLocalTranscriptionComponents({
-      reason: options.reason || "first-use",
+      reason: promptReason,
       readiness: requiredReadiness,
       requireAsr,
       requireOcr
     });
+    await this.clearLocalComponentInstallPromptSnooze();
     const nextReadiness = this.getLocalTranscriptionComponentReadiness();
     const stillAsrMissing = requireAsr && (!nextReadiness.asrStatus || !nextReadiness.asrStatus.ready);
     const stillOcrMissing = requireOcr && (!nextReadiness.ocrStatus || !nextReadiness.ocrStatus.ready);

--- a/obsidian-plugin/wechat-inbox-sync/main.js
+++ b/obsidian-plugin/wechat-inbox-sync/main.js
@@ -19975,14 +19975,24 @@ var _LocalComponentInstallConfirmModal = class _LocalComponentInstallConfirmModa
     this.message.split("\n").map((line) => line.trim()).filter(Boolean).forEach((line) => contentEl.createEl("p", { text: line }));
     const buttonRow = contentEl.createDiv({ cls: "wechat-inbox-sync-modal-actions" });
     const confirmButton = buttonRow.createEl("button", { text: "开始安装/修复" });
+    confirmButton.type = "button";
     if (typeof confirmButton.addClass === "function") {
       confirmButton.addClass("mod-cta");
     } else {
       confirmButton.className = `${confirmButton.className || ""} mod-cta`.trim();
     }
-    confirmButton.addEventListener("click", () => this.finish(true));
+    confirmButton.addEventListener("click", (event) => {
+      if (event && typeof event.preventDefault === "function") event.preventDefault();
+      if (event && typeof event.stopPropagation === "function") event.stopPropagation();
+      this.finish(true);
+    });
     const laterButton = buttonRow.createEl("button", { text: "稍后再试" });
-    laterButton.addEventListener("click", () => this.finish(false));
+    laterButton.type = "button";
+    laterButton.addEventListener("click", (event) => {
+      if (event && typeof event.preventDefault === "function") event.preventDefault();
+      if (event && typeof event.stopPropagation === "function") event.stopPropagation();
+      this.finish(false);
+    });
   }
   onClose() {
     if (this.contentEl) this.contentEl.empty();
@@ -22248,6 +22258,26 @@ var _WechatObsidianInboxPlugin = class _WechatObsidianInboxPlugin extends Plugin
       ocrStatus
     };
   }
+  isLocalComponentInstallPromptSnoozed(reason = "") {
+    if (reason === "manual-refresh") return false;
+    const snoozedUntil = Date.parse(this.settings.proSetupInstallPromptSnoozedUntil || "");
+    return Number.isFinite(snoozedUntil) && Date.now() < snoozedUntil;
+  }
+  async snoozeLocalComponentInstallPrompt(now = Date.now()) {
+    const snoozedUntil = new Date(now + PRO_SETUP_PROMPT_COOLDOWN_MS).toISOString();
+    await this.saveSettings({
+      ...this.settings,
+      proSetupInstallPromptSnoozedUntil: snoozedUntil
+    });
+    return snoozedUntil;
+  }
+  async clearLocalComponentInstallPromptSnooze() {
+    if (!this.settings.proSetupInstallPromptSnoozedUntil) return;
+    await this.saveSettings({
+      ...this.settings,
+      proSetupInstallPromptSnoozedUntil: ""
+    });
+  }
   async refreshProAndMaybePromptLocalComponentInstall(options = {}) {
     const reason = options.reason || "settings-open";
     const now = Date.now();
@@ -22285,12 +22315,25 @@ var _WechatObsidianInboxPlugin = class _WechatObsidianInboxPlugin extends Plugin
       };
       const shouldInstallMissingComponents = options.installMissingComponents === true || reason === "manual-refresh";
       if (shouldInstallMissingComponents && refreshPlan.hasRequiredChanges) {
+        if (this.isLocalComponentInstallPromptSnoozed(reason)) {
+          status = {
+            ...status,
+            localComponentInstallSkipped: {
+              reason: "snoozed",
+              snoozedUntil: this.settings.proSetupInstallPromptSnoozedUntil,
+              ...refreshPlan
+            }
+          };
+          return status;
+        }
         const accepted = await this.confirmLocalComponentInstall(status, reason, readiness);
         if (!accepted) {
+          const snoozedUntil = await this.snoozeLocalComponentInstallPrompt(now);
           status = {
             ...status,
             localComponentInstallSkipped: {
               reason: "user-declined",
+              snoozedUntil,
               ...refreshPlan
             }
           };
@@ -22321,6 +22364,7 @@ var _WechatObsidianInboxPlugin = class _WechatObsidianInboxPlugin extends Plugin
             localComponentReadiness: readiness,
             localComponentRefreshPlan: refreshPlan
           };
+          await this.clearLocalComponentInstallPromptSnooze();
         } catch (error) {
           const failedReadiness = this.getLocalTranscriptionComponentReadiness();
           status = {
@@ -22466,16 +22510,22 @@ var _WechatObsidianInboxPlugin = class _WechatObsidianInboxPlugin extends Plugin
       ready: false,
       missingComponents
     };
-    const accepted = await this.confirmLocalComponentInstall(status, options.reason || "first-use", requiredReadiness);
+    const promptReason = options.reason || "first-use";
+    if (this.isLocalComponentInstallPromptSnoozed(promptReason)) {
+      throw new Error(`${featureName}需要先安装本地转写组件；你已选择稍后再试，请在插件设置里点击“刷新权限”后安装/修复。`);
+    }
+    const accepted = await this.confirmLocalComponentInstall(status, promptReason, requiredReadiness);
     if (!accepted) {
+      await this.snoozeLocalComponentInstallPrompt();
       throw new Error(`${featureName}需要先安装本地转写组件。`);
     }
     await this.installLocalTranscriptionComponents({
-      reason: options.reason || "first-use",
+      reason: promptReason,
       readiness: requiredReadiness,
       requireAsr,
       requireOcr
     });
+    await this.clearLocalComponentInstallPromptSnooze();
     const nextReadiness = this.getLocalTranscriptionComponentReadiness();
     const stillAsrMissing = requireAsr && (!nextReadiness.asrStatus || !nextReadiness.asrStatus.ready);
     const stillOcrMissing = requireOcr && (!nextReadiness.ocrStatus || !nextReadiness.ocrStatus.ready);

--- a/obsidian-plugin/wechat-inbox-sync/src/main.js
+++ b/obsidian-plugin/wechat-inbox-sync/src/main.js
@@ -13867,15 +13867,25 @@ class LocalComponentInstallConfirmModal extends LocalComponentInstallConfirmModa
 
     const buttonRow = contentEl.createDiv({ cls: 'wechat-inbox-sync-modal-actions' });
     const confirmButton = buttonRow.createEl('button', { text: '开始安装/修复' });
+    confirmButton.type = 'button';
     if (typeof confirmButton.addClass === 'function') {
       confirmButton.addClass('mod-cta');
     } else {
       confirmButton.className = `${confirmButton.className || ''} mod-cta`.trim();
     }
-    confirmButton.addEventListener('click', () => this.finish(true));
+    confirmButton.addEventListener('click', (event) => {
+      if (event && typeof event.preventDefault === 'function') event.preventDefault();
+      if (event && typeof event.stopPropagation === 'function') event.stopPropagation();
+      this.finish(true);
+    });
 
     const laterButton = buttonRow.createEl('button', { text: '稍后再试' });
-    laterButton.addEventListener('click', () => this.finish(false));
+    laterButton.type = 'button';
+    laterButton.addEventListener('click', (event) => {
+      if (event && typeof event.preventDefault === 'function') event.preventDefault();
+      if (event && typeof event.stopPropagation === 'function') event.stopPropagation();
+      this.finish(false);
+    });
   }
 
   onClose() {
@@ -16416,6 +16426,29 @@ class WechatObsidianInboxPlugin extends Plugin {
     };
   }
 
+  isLocalComponentInstallPromptSnoozed(reason = '') {
+    if (reason === 'manual-refresh') return false;
+    const snoozedUntil = Date.parse(this.settings.proSetupInstallPromptSnoozedUntil || '');
+    return Number.isFinite(snoozedUntil) && Date.now() < snoozedUntil;
+  }
+
+  async snoozeLocalComponentInstallPrompt(now = Date.now()) {
+    const snoozedUntil = new Date(now + PRO_SETUP_PROMPT_COOLDOWN_MS).toISOString();
+    await this.saveSettings({
+      ...this.settings,
+      proSetupInstallPromptSnoozedUntil: snoozedUntil,
+    });
+    return snoozedUntil;
+  }
+
+  async clearLocalComponentInstallPromptSnooze() {
+    if (!this.settings.proSetupInstallPromptSnoozedUntil) return;
+    await this.saveSettings({
+      ...this.settings,
+      proSetupInstallPromptSnoozedUntil: '',
+    });
+  }
+
   async refreshProAndMaybePromptLocalComponentInstall(options = {}) {
     const reason = options.reason || 'settings-open';
     const now = Date.now();
@@ -16463,12 +16496,25 @@ class WechatObsidianInboxPlugin extends Plugin {
         || reason === 'manual-refresh'
       );
       if (shouldInstallMissingComponents && refreshPlan.hasRequiredChanges) {
+        if (this.isLocalComponentInstallPromptSnoozed(reason)) {
+          status = {
+            ...status,
+            localComponentInstallSkipped: {
+              reason: 'snoozed',
+              snoozedUntil: this.settings.proSetupInstallPromptSnoozedUntil,
+              ...refreshPlan,
+            },
+          };
+          return status;
+        }
         const accepted = await this.confirmLocalComponentInstall(status, reason, readiness);
         if (!accepted) {
+          const snoozedUntil = await this.snoozeLocalComponentInstallPrompt(now);
           status = {
             ...status,
             localComponentInstallSkipped: {
               reason: 'user-declined',
+              snoozedUntil,
               ...refreshPlan,
             },
           };
@@ -16501,6 +16547,7 @@ class WechatObsidianInboxPlugin extends Plugin {
             localComponentReadiness: readiness,
             localComponentRefreshPlan: refreshPlan,
           };
+          await this.clearLocalComponentInstallPromptSnooze();
         } catch (error) {
           const failedReadiness = this.getLocalTranscriptionComponentReadiness();
           status = {
@@ -16670,16 +16717,22 @@ class WechatObsidianInboxPlugin extends Plugin {
       missingComponents,
     };
 
-    const accepted = await this.confirmLocalComponentInstall(status, options.reason || 'first-use', requiredReadiness);
+    const promptReason = options.reason || 'first-use';
+    if (this.isLocalComponentInstallPromptSnoozed(promptReason)) {
+      throw new Error(`${featureName}需要先安装本地转写组件；你已选择稍后再试，请在插件设置里点击“刷新权限”后安装/修复。`);
+    }
+    const accepted = await this.confirmLocalComponentInstall(status, promptReason, requiredReadiness);
     if (!accepted) {
+      await this.snoozeLocalComponentInstallPrompt();
       throw new Error(`${featureName}需要先安装本地转写组件。`);
     }
     await this.installLocalTranscriptionComponents({
-      reason: options.reason || 'first-use',
+      reason: promptReason,
       readiness: requiredReadiness,
       requireAsr,
       requireOcr,
     });
+    await this.clearLocalComponentInstallPromptSnooze();
 
     const nextReadiness = this.getLocalTranscriptionComponentReadiness();
     const stillAsrMissing = requireAsr && (!nextReadiness.asrStatus || !nextReadiness.asrStatus.ready);

--- a/release-candidate.json
+++ b/release-candidate.json
@@ -3,8 +3,8 @@
   "pluginId": "wechat-inbox-sync",
   "pluginVersion": "1.3.124",
   "sourceRoot": "obsidian-plugin/wechat-inbox-sync",
-  "candidateId": "1.3.124-2d85cc2af8b9dba9",
-  "aggregateSha256": "2d85cc2af8b9dba90993df8db9a24427c55a7e4045575afcfa6dcd1fc78e509a",
+  "candidateId": "1.3.124-062ef5bd3bca288b",
+  "aggregateSha256": "062ef5bd3bca288b57ba8d5a9db49a24b6778732f99d99c8e928596be39c87ee",
   "looseAssets": [
     "main.js",
     "manifest.json",
@@ -64,8 +64,8 @@
     },
     {
       "path": "main.js",
-      "bytes": 2424021,
-      "sha256": "80bf1f3f072e781a95fd57549f227353ad47f897bc6864a01c965b4aa4eaa1c4"
+      "bytes": 2426173,
+      "sha256": "d99fc9260699b0936afd598c3ef4b6591621f181da9f3f36b98073bac0afc1e1"
     },
     {
       "path": "manifest.json",

--- a/tests/plugin-local-component-on-demand.test.js
+++ b/tests/plugin-local-component-on-demand.test.js
@@ -109,8 +109,50 @@ async function verifyManualRefreshDeclineSkipsDownload() {
   assert.strictEqual(status.hasAccess, true);
   assert.strictEqual(prompts, 1);
   assert.strictEqual(status.localComponentInstallSkipped.reason, 'user-declined');
+  assert.ok(Date.parse(status.localComponentInstallSkipped.snoozedUntil) > Date.now());
+  assert.strictEqual(plugin.settings.proSetupInstallPromptSnoozedUntil, status.localComponentInstallSkipped.snoozedUntil);
   assert.strictEqual(status.localComponentInstallSkipped.requireAsr, false);
   assert.strictEqual(status.localComponentInstallSkipped.requireOcr, true);
+}
+
+async function verifyFirstUseDeclineSnoozesPromptAndSkipsRepeatedDialogs() {
+  const plugin = createPlugin();
+  let prompts = 0;
+  let installs = 0;
+  plugin.ensureProFeatureAccess = async () => ({ hasAccess: true, status: 'active' });
+  plugin.getLocalAsrInstallStatus = () => ({ ready: false });
+  plugin.getLocalOcrInstallStatus = () => ({ ready: true });
+  plugin.confirmLocalComponentInstall = async () => {
+    prompts += 1;
+    return false;
+  };
+  plugin.installLocalTranscriptionComponents = async () => {
+    installs += 1;
+    throw new Error('declined first-use prompt must not install components');
+  };
+
+  await assert.rejects(
+    () => plugin.ensureLocalComponentReadyForUse('音视频转写', {
+      reason: 'first-use',
+      requireAsr: true,
+      requireOcr: false,
+    }),
+    /需要先安装本地转写组件/,
+  );
+  assert.strictEqual(prompts, 1);
+  assert.strictEqual(installs, 0);
+  assert.ok(Date.parse(plugin.settings.proSetupInstallPromptSnoozedUntil) > Date.now());
+
+  await assert.rejects(
+    () => plugin.ensureLocalComponentReadyForUse('音视频转写', {
+      reason: 'first-use',
+      requireAsr: true,
+      requireOcr: false,
+    }),
+    /已选择稍后再试/,
+  );
+  assert.strictEqual(prompts, 1);
+  assert.strictEqual(installs, 0);
 }
 
 async function verifyManualRefreshUpdatesCompatibleLegacyComponentsOnlyAfterConfirmation() {
@@ -172,6 +214,52 @@ async function verifyManualRefreshUpdatesCompatibleLegacyComponentsOnlyAfterConf
   assert.strictEqual(installOptions[0].requireOcr, true);
   assert.strictEqual(installOptions[0].forceAsr, true);
   assert.strictEqual(installOptions[0].forceOcr, true);
+}
+
+async function verifyManualRefreshIgnoresPromptSnoozeAndClearsItAfterInstall() {
+  const plugin = createPlugin();
+  let prompts = 0;
+  const installOptions = [];
+  plugin.settings = helpers.mergeSettings({
+    proSetupInstallPromptSnoozedUntil: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+  });
+  plugin.getProFeatureAccessStatus = async () => ({ hasAccess: true, status: 'active' });
+  plugin.getLocalTranscriptionComponentReadiness = () => ({
+    ready: false,
+    missingComponents: ['OCR'],
+    asrStatus: { ready: true },
+    ocrStatus: { ready: false },
+  });
+  plugin.confirmLocalComponentInstall = async (status, reason) => {
+    prompts += 1;
+    assert.strictEqual(status.hasAccess, true);
+    assert.strictEqual(reason, 'manual-refresh');
+    return true;
+  };
+  plugin.installLocalTranscriptionComponents = async (options) => {
+    installOptions.push(options);
+    return {
+      installed: true,
+      reason: options.reason,
+      readiness: {
+        ready: true,
+        missingComponents: [],
+        updateComponents: [],
+        asrStatus: { ready: true },
+        ocrStatus: { ready: true },
+      },
+    };
+  };
+
+  const status = await plugin.refreshProAndMaybePromptLocalComponentInstall({
+    reason: 'manual-refresh',
+    force: true,
+  });
+
+  assert.strictEqual(prompts, 1);
+  assert.strictEqual(installOptions.length, 1);
+  assert.strictEqual(status.localComponentInstallResult.installed, true);
+  assert.strictEqual(plugin.settings.proSetupInstallPromptSnoozedUntil, '');
 }
 
 function verifyRefreshPlanOnlyIncludesOptionalUpdatesWhenRequested() {
@@ -243,7 +331,9 @@ async function verifyImplicitInstallIsNoOp() {
 (async () => {
   await verifyStatusRefreshPromptsAndInstallsMissingComponentsOnlyOnManualRefresh();
   await verifyManualRefreshDeclineSkipsDownload();
+  await verifyFirstUseDeclineSnoozesPromptAndSkipsRepeatedDialogs();
   await verifyManualRefreshUpdatesCompatibleLegacyComponentsOnlyAfterConfirmation();
+  await verifyManualRefreshIgnoresPromptSnoozeAndClearsItAfterInstall();
   verifyRefreshPlanOnlyIncludesOptionalUpdatesWhenRequested();
   await verifyFirstUseInstallsOnlyRequestedComponent({ requireAsr: true, requireOcr: false });
   await verifyFirstUseInstallsOnlyRequestedComponent({ requireAsr: false, requireOcr: true });

--- a/tests/plugin-main-ai.test.js
+++ b/tests/plugin-main-ai.test.js
@@ -2497,6 +2497,10 @@ assert.ok(pluginMainSource.includes('refreshProAndMaybePromptLocalComponentInsta
 assert.ok(pluginMainSource.includes('installLocalTranscriptionComponents'));
 assert.ok(pluginMainSource.includes('confirmLocalComponentInstall'));
 assert.ok(pluginMainSource.includes("createEl('button', { text: '稍后再试' })"));
+assert.ok(pluginMainSource.includes("confirmButton.type = 'button'"));
+assert.ok(pluginMainSource.includes("laterButton.type = 'button'"));
+assert.ok(pluginMainSource.includes('proSetupInstallPromptSnoozedUntil'));
+assert.ok(pluginMainSource.includes('isLocalComponentInstallPromptSnoozed'));
 assert.ok(pluginMainSource.includes('ensureLocalComponentReadyForUse'));
 assert.ok(pluginMainSource.includes('PRO_SETUP_CHECK_INTERVAL_MS'));
 assert.ok(pluginMainSource.includes('PRO_SETUP_PROMPT_COOLDOWN_MS'));


### PR DESCRIPTION
## Summary
- make the local component install prompt dismissible in Obsidian/Windows by hardening modal button handling
- snooze declined first-use prompts so users are not trapped in repeated install dialogs
- keep manual Pro refresh authoritative: it ignores prompt snooze, checks local component state, repairs only missing/outdated components, and clears snooze after success
- refresh release candidate hashes for 1.3.124

## Tests
- node --check obsidian-plugin\\wechat-inbox-sync\\src\\main.js
- node --check tests\\plugin-local-component-on-demand.test.js
- node --check tests\\plugin-main-ai.test.js
- node tests\\plugin-local-component-on-demand.test.js
- PYTHON=D:\\AIbc\\Python312\\python.exe node tests\\plugin-main-ai.test.js
- npm run build
- node scripts\\sync-plugin-release-mirror.js --write --source obsidian-plugin\\wechat-inbox-sync --root .
- node tests\\plugin-marketplace-package.test.js
- node scripts\\sync-plugin-release-mirror.js --check --source obsidian-plugin\\wechat-inbox-sync --root .
- node scripts\\update-local-components-manifest.js --check
- node tests\\release-governance.test.js
- node tests\\plugin-release-candidate.test.js
- node tests\\plugin-release-identity.test.js
- node tests\\plugin-local-candidate-regressions.test.js
- node tests\\plugin-sync-history.test.js