### PR TITLE
Align 1.3.137 social login popup regression

### DIFF
--- a/tests/plugin-xiaohongshu-login-window.test.js
+++ b/tests/plugin-xiaohongshu-login-window.test.js
@@ -52,11 +52,19 @@ helpers.installXiaohongshuLoginWindowGuards({
   },
 });
 assert.strictEqual(typeof windowOpenHandler, 'function');
-assert.deepStrictEqual(
-  windowOpenHandler({ url: 'https://www.xiaohongshu.com/explore/another-note' }),
-  { action: 'deny' },
-  'the visible login window must not let the page spawn more Xiaohongshu windows',
+const allowedLoginPopup = windowOpenHandler({
+  url: 'https://www.xiaohongshu.com/explore/another-note',
+});
+assert.strictEqual(
+  allowedLoginPopup.action,
+  'allow',
+  'the visible login window must allow a Xiaohongshu-owned authentication popup',
 );
+assert.deepStrictEqual(allowedLoginPopup.overrideBrowserWindowOptions.webPreferences, {
+  contextIsolation: true,
+  nodeIntegration: false,
+  sandbox: true,
+});
 assert.deepStrictEqual(
   windowOpenHandler({ url: 'https://example.com/' }),
   { action: 'deny' },


### PR DESCRIPTION
## Summary
- align the existing Xiaohongshu login-window regression with the trusted popup behavior in 1.3.137
- retain external-domain denial and secure child webPreferences assertions
- no plugin release asset bytes change

## Verification
- node tests/plugin-xiaohongshu-login-window.test.js passed
- independent review remains GO (P0=0, P1=0)